### PR TITLE
Depends on uvicorn-standard package not just uvicorn

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 252e970b3e1a27b594cc7b3685238691bf8eaa232225d4dee9e33ec83580775f
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,7 +54,7 @@ requirements:
     - tokenizers >=0.13.2
     - tqdm >=4.65.0
     - typing-extensions >=4.5.0
-    - uvicorn >=0.18.3
+    - uvicorn-standard >=0.18.3
 
 test:
   imports:


### PR DESCRIPTION
Chromadb has depended on the "uvicorn[standard]" pypi package since 0.1.0. See https://github.com/chroma-core/chroma/commit/dfb1f7f4034f70f25455ac82b08143f911fefc72. The corresponding conda package is uvicorn-standard not uvicorn. 

See the uvicorn feedstock: https://github.com/conda-forge/uvicorn-feedstock/blob/main/recipe/meta.yaml

I'll open a PR to patch previous versions once this is merged. https://conda-forge.org/docs/maintainer/updating_pkgs/#removing-broken-packages

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
