### PR TITLE
Relax constraint on fastapi to be '>=' opposed to strict '=='

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,7 +16,7 @@ source:
     file_name: LICENSE
 
 build:
-  number: 1
+  number: 2
   # Missing onnxruntime builds
   skip: osx and x86_64 and match(python, ">=3.14")
   script:
@@ -46,7 +46,7 @@ requirements:
   run:
     - python
     - bcrypt >=4.0.1
-    - fastapi ==0.115.9
+    - fastapi >=0.115.9
     - graphlib-backport >=1.0.3
     - grpcio >=1.58.0
     - httpx >=0.27.0


### PR DESCRIPTION
The chromadb project depends on fastapi >= 0.115.9. 

ref: https://github.com/chroma-core/chroma/blob/1.5.7/pyproject.toml#L13

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
